### PR TITLE
Refactoring and tidying up the normalization calls

### DIFF
--- a/bin/simple.py
+++ b/bin/simple.py
@@ -41,7 +41,8 @@ parser.add_argument("--curl", action='store_true',help='curl reconstruction')
 
 args = parser.parse_args()
 
-solint,ils,Als,Nl,comm,rank,my_tasks,sindex,debug_cmb,lmin,lmax,polcomb,nsims,channel,isostr = solenspipe.initialize_args(args)
+solint,Als,Als_curl,Nl,comm,rank,my_tasks,sindex,debug_cmb,lmin,lmax,polcomb,nsims,channel,isostr = solenspipe.initialize_args(args)
+ils=Als['L']
 
 w1 = solint.wfactor(1)      
 w2 = solint.wfactor(2)

--- a/solenspipe/solenspipe.py
+++ b/solenspipe/solenspipe.py
@@ -14,6 +14,7 @@ from falafel import qe
 import os
 import glob
 import traceback
+from collections import OrderedDict
 
 config = io.config_from_yaml(os.path.dirname(os.path.abspath(__file__)) + "/../input/config.yml")
 opath = config['data_path']
@@ -495,38 +496,127 @@ class SOLensInterface(object):
         return ls,nells,nells_P
     
 
-    def initialize_norm(self,ch,lmin,lmax,recalculate=False,quicklens=False,curl=False,label=None):
+    def initialize_norm(self, channel, lmin, lmax, recalculate=False,
+                        cmblensplus=True, label=None):
+        """
+        Calculate the normalization factors A(L) to normalize
+        the kappa a_lms (see e.g. https://arxiv.org/abs/astro-ph/0111606).
+        Return a recarray of A(L) values, as well as writing these
+        to file for subsequent use.
+        
+        Parameters
+        ----------
+        channel: mapsims.Channel instance
+            the channel to calculate the A(L)s for
+        lmin: int
+            minimum l in reconstruced kappa
+        lmax: int
+            maxmimum l in rconstructed kappa
+        recalculate: bool
+            if True, perform the calculation, otherwise
+        use read from file.
+        cmblensplus: bool (default=True)
+            if True, use cmblensplus to do the calculation,
+        otherwise use qe.symlens_norm
+        label: str
+            An identifer string used in the output text file,
+        (or in the input filename if recalculate is False)
+
+        Returns
+        -------
+        Als: numpy recarray
+            recarray of norm info, (including the L
+        values). Columns are accessible by name e.g.
+        Als["L"] or Als["TT"]
+        Als_curl: numpy recarray or None
+            same as Als but for the curl. In the case
+        that no cached file is found, or we do the 
+        calculation with qe.symlens_norm, we return
+        None instead.
+        """
+
+        #Build the filenames.
         lstr = "" if label is None else f"{label}_"
         wstr = "" if self.wnoise is None else "wnoise_"
-        onormfname = opath+"norm_%s%slmin_%d_lmax_%d.txt" % (wstr,lstr,lmin,lmax)
-        onormcurlfname = opath+"norm_%s%slmin_%d_lmax_%d.txt" % (wstr,lstr,lmin,lmax)
-        try:
-            assert not(recalculate), "Recalculation of norm requested."
-            if curl:
-                print("using curl norm")
-                print(onormcurlfname)
-                return np.loadtxt(onormcurlfname,unpack=True)
-            else:
-                return np.loadtxt(onormfname,unpack=True)
-        except:
-            print(traceback.format_exc())
-            thloc = os.path.dirname(os.path.abspath(__file__)) + "/../data/" + config['theory_root']
-            theory = cosmology.loadTheorySpectraFromCAMB(thloc,get_dimensionless=False)
-            ells,gt = np.loadtxt(f"{thloc}_camb_1.0.12_grads.dat",unpack=True,usecols=[0,1])
+        als_fname = opath+"als_%s%slmin_%d_lmax_%d.txt" % (wstr,lstr,lmin,lmax)
+        als_curl_fname = opath+"als_curl_%s%slmin_%d_lmax_%d.txt" % (wstr,lstr,lmin,lmax)
 
+        #stuff for reading/writing the cached files. Assuming for now
+        #they should be human readable, if not - we could simplify
+        #these reading and writing steps quite a lot by using
+        #.yaml or .npy files.
+        AL_data_dtype = [("L",int), ("TT",float), ("TE",float), ("EE",float),
+                         ("TB",float), ("EB",float), ("mv",float),
+                         ("mv_pol",float), ("TE_hdv",float)]
+        AL_data_names = [d[0] for d in AL_data_dtype]
+        #format for savetxt - all floats execept L column
+        savetxt_fmt = ["%.18e" if d[1]==float else "%d" for d in AL_data_dtype]
+        def write_als(Als, filename):
+            output_data = np.zeros(len(Als['L']), dtype=AL_data_dtype)
+            for d in AL_data_dtype:
+                output_data[d[0]] = Als[d[0]]
+            np.savetxt(filename, output_data, fmt=savetxt_fmt,
+                       header='#'+" ".join(AL_data_names)
+                       )
+        def read_als(filename):
+            AL_data = np.genfromtxt(filename, names=True)
+            #Make sure we have the correct columns
+            print(AL_data.dtype.names)
+            print(AL_data_names)
+            assert list(AL_data.dtype.names) == AL_data_names
+            return AL_data
+
+        #If not calculating, just read in from files
+        #and return the arrays. For now, we do not throw
+        #an error if the curl file is not found.
+        if not recalculate:
+            print("reading A(L)s from %s, %s"%(als_fname, als_curl_fname))
+            try:
+                als_data = read_als(als_fname)
+            except IOError as e:
+                print("A(L)s file %s not found"%als_fname)
+                raise(e)
+            try:
+                als_curl_data = read_als(als_curl_fname)
+            except IOError as e:
+                print("A(L)s file for curl %s not found"%als_curl_fname)
+                print("Continuing for now in case you didn't need curl anyway")
+                als_curl_data = None
+                pass
+            return als_data, als_curl_data        
+
+        else:
+            #In this case we do the calculation
+            #First read in the theory
+            thloc = (os.path.dirname(os.path.abspath(__file__))
+                     + "/../data/" + config['theory_root'])
+            theory = cosmology.loadTheorySpectraFromCAMB(
+                thloc,get_dimensionless=False)
+            ells,gt = np.loadtxt(f"{thloc}_camb_1.0.12_grads.dat",
+                                 unpack=True,usecols=[0,1])
             class T:
                 def __init__(self):
                     self.lCl = lambda p,x: maps.interp(ells,gt)(x)
             theory_cross = T()
-            ls,nells,nells_P = self.get_noise_power(ch,beam_deconv=True)
+            ls,nells,nells_P = self.get_noise_power(channel,
+                                                    beam_deconv=True)
             cltt=theory.lCl('TT',ls)+nells
-
-            if quicklens: #now cmblensplus
-                Als = {}
-                Acs={}
-                ls,Ag,Ac = cmblensplus_norm(nells,nells_P,nells_P,theory,theory_cross,lmin,lmax)
-                Als['TT']=Ag[0];Als['TE']=Ag[1];Als['EE']=Ag[2];Als['TB']=Ag[3];Als['EB']=Ag[4];al_mv =1/(1/Als['EB']+1/Als['TB']+1/Als['EE']+1/Als['TE']+1/Als['TT']);al_mv_pol = 1/(1/Als['EB']+1/Als['TB']);Al_te_hdv = Als['TT']*0 
-                Acs['TT']=Ac[0];Acs['TE']=Ac[1];Acs['EE']=Ac[2];Acs['TB']=Ac[3];Acs['EB']=Ac[4];ac_mv =1/(1/Acs['EB']+1/Acs['TB']+1/Acs['EE']+1/Acs['TE']+1/Acs['TT']);ac_mv_pol = 1/(1/Acs['EB']+1/Acs['TB']);Ac_te_hdv = Acs['TT']*0 
+            Als = np.zeros(lmax+1, dtype=AL_data_dtype)
+            Als_curl = np.zeros_like(Als)
+            if cmblensplus:
+                ls, Ag, Ac = cmblensplus_norm(
+                    nells, nells_P, nells_P, theory,
+                    theory_cross, lmin,lmax)
+                def fill_array(L, Ain, Aout):
+                    Aout['L'] = L
+                    Aout['TT'], Aout['TE'], Aout['EE'], Aout['TB'], Aout['EB'] = (
+                        Ag[0], Ag[1], Ag[2], Ag[3], Ag[4])
+                    Als['mv'] = 1/(1/Als['EB']+1/Als['TB']+
+                              1/Als['EE']+1/Als['TE']+1/Als['TT'])
+                    Als['mv_pol'] = 1/(1/Als['EB']+1/Als['TB'])
+                    Als['TE_hdv'] = 0.
+                fill_array(ls, Ag, Als)
+                fill_array(ls, Ac, Als_curl)
             else:
                 ells = np.arange(lmax+100)
                 uctt = theory.lCl('TT',ells)
@@ -537,15 +627,27 @@ class SOLensInterface(object):
                 tcee = ucee + maps.interp(ls,nells_P)(ells)
                 tcte = ucte 
                 tcbb = ucbb + maps.interp(ls,nells_P)(ells)
-                ls,Als,al_mv_pol,al_mv,Al_te_hdv = qe.symlens_norm(uctt,tctt,ucee,tcee,ucte,tcte,ucbb,tcbb,lmin=lmin,lmax=lmax,plot=False)
-            io.save_cols(onormfname,(ls,Als['TT'],Als['EE'],Als['EB'],Als['TE'],Als['TB'],al_mv_pol,al_mv,Al_te_hdv))
-            io.save_cols(onormcurlfname,(ls,Acs['TT'],Acs['EE'],Acs['EB'],Acs['TE'],Acs['TB'],ac_mv_pol,ac_mv,Ac_te_hdv))
-            if curl:
-                print("curl norm")
-                return ls,Acs['TT'],Acs['EE'],Acs['EB'],Acs['TE'],Acs['TB'],ac_mv_pol,ac_mv,Ac_te_hdv
-            else: 
-                return ls,Als['TT'],Als['EE'],Als['EB'],Als['TE'],Als['TB'],al_mv_pol,al_mv,Al_te_hdv
-    
+                ls,Al,al_mv_pol,al_mv,Al_te_hdv = qe.symlens_norm(
+                    uctt,tctt,ucee,tcee,ucte,tcte,ucbb,tcbb,lmin=lmin,
+                    lmax=lmax,plot=False)
+                Als = np.zeros(len(ls), dtype=AL_data_dtype)
+                Als['L'] = ls
+                for key in ['TT','EE','EB','TE','TB']:
+                    Als[key] = Al[key][:lmax+1]
+                Als['mv_pol'] = al_mv_pol[:lmax+1]
+                Als['mv'] = al_mv[:lmax+1]
+                Als['TE_hdv'] = Al_te_hdv[:lmax+1]
+                #qe.symlens_norm doesn't do the curl so set this to None
+                Als_curl = None
+
+            #Now write the files which can be used in subsequent
+            #calls with recalculate=False
+            write_als(Als, als_fname)
+            if Als_curl is not None:
+                write_als(Als_curl, als_curl_fname)
+
+            return Als, Als_curl
+        
     def analytic_n1(self,ch,lmin,lmax,Lmin_out=2,Lmaxout=3000,Lstep=20,label=None):
         
         from solenspipe import biastheory as nbias

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -1,0 +1,40 @@
+#Test the SOLensPipe.initalize_norm
+from solenspipe import SOLensInterface, get_mask
+import mapsims
+import numpy as np
+
+#Test that caching of the norm is working by
+#running initialize_norm twice - once with
+#recalculate=True, and then once with
+#recalculate=False, and make sure they give
+#the same answer. Do this with cmblensplus
+#True and False
+def test_norm_caching():
+    mask = get_mask()
+    beam_fwhm = 1.4
+    white_noise = 30.
+    solint = SOLensInterface(mask=mask, beam_fwhm=beam_fwhm,
+                               white_noise=white_noise)
+    channel = mapsims.SOChannel("LA", 145)
+    lmin,lmax=200,1000
+
+    for cmblensplus in [True,False]:
+        #Run once with recalculate=True
+        ALs,ALs_curl = solint.initialize_norm(
+            channel,lmin,lmax,
+            recalculate=True,cmblensplus=True)
+        #Run again with recaclulate=False
+        ALs_cached,ALs_curl_cached = solint.initialize_norm(
+            channel,lmin,lmax,
+            recalculate=False,cmblensplus=True)
+        for col in ALs.dtype.names:
+            np.testing.assert_array_equal(ALs[col], ALs_cached[col])
+            if ALs_curl is not None:
+                np.testing.assert_array_equal(ALs_curl[col],
+                                              ALs_curl_cached[col]
+                                              )
+
+
+            
+if __name__=="__main__":
+    test_norm_caching()

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -18,22 +18,22 @@ def test_norm_caching():
     channel = mapsims.SOChannel("LA", 145)
     lmin,lmax=200,1000
 
-    for cmblensplus in [True,False]:
+    for use_cmblensplus in [True,False]:
         #Run once with recalculate=True
         ALs,ALs_curl = solint.initialize_norm(
             channel,lmin,lmax,
-            recalculate=True,cmblensplus=True)
+            recalculate=True,use_cmblensplus=use_cmblensplus)
         #Run again with recaclulate=False
         ALs_cached,ALs_curl_cached = solint.initialize_norm(
             channel,lmin,lmax,
-            recalculate=False,cmblensplus=True)
+            recalculate=False,use_cmblensplus=use_cmblensplus)
         for col in ALs.dtype.names:
             np.testing.assert_array_equal(ALs[col], ALs_cached[col])
             if ALs_curl is not None:
                 np.testing.assert_array_equal(ALs_curl[col],
                                               ALs_curl_cached[col]
                                               )
-
+    print("test passed!")
 
             
 if __name__=="__main__":


### PR DESCRIPTION
This pull request mostly just tidies up the `SOLensPipe.initialize_normalization`. Specifically, we add a doc string, tidy up and clarify the code, simplify the return value (now just two recarrays, from which you can extract the relevant normalization by name), and ensure this return value format is consistent for the different available options. 

There is also a unit test in `tests/test_norm.py` that ensures the caching of the normalization is working correctly. We could aspire to adding a little test function of this sort for any non-trivial methods of `SOLensPipe`.

I have left the caching so that the cached files are human readable (i.e. ascii, with a header), but if we don't wanl this we could simplify the code further. I'm also thinking we could make this normalization data attributes of the SOLensPipe instance, which would simplify code using this functionality, but didn't do that yet in case there is some reason not to. 

I updated `bin/simple.py` to account for the changes to `initialize_normalization`, although this was a very minor change. @qujia7 have a look at that and if you doing this in other exectuable files it should be obvious how to make the update.  

Finally, and less relatedly, I also added here a jupyter notebook with some basic usage of the `SOLensPipe` class. 