### PR TITLE
Sim conflict in rdn0

### DIFF
--- a/solenspipe/bias.py
+++ b/solenspipe/bias.py
@@ -113,7 +113,7 @@ def mcrdn0(icov, get_kmap, power, nsims, qfunc1, qfunc2=None, Xdat=None, use_mpi
         
 
     for i in my_tasks:
-        i=i+1
+        i=i+2 #reserve seed 0 for data and seed 1 for sim 1 testing
         if rank==0 and verbose: print("MCRDN0: Rank %d doing task %d" % (rank,i))
         Xs  = get_kmap((icov,0,i))
         if not(skip_rd): 

--- a/solenspipe/bias.py
+++ b/solenspipe/bias.py
@@ -113,6 +113,7 @@ def mcrdn0(icov, get_kmap, power, nsims, qfunc1, qfunc2=None, Xdat=None, use_mpi
         
 
     for i in my_tasks:
+        i=i+1
         if rank==0 and verbose: print("MCRDN0: Rank %d doing task %d" % (rank,i))
         Xs  = get_kmap((icov,0,i))
         if not(skip_rd): 
@@ -279,6 +280,7 @@ def mcn1(icov,get_kmap,power,nsims,qfunc1,qfunc2=None,comm=None,verbose=True):
     comm,rank,my_tasks = mpi.distribute(nsims)
     n1evals = []
     for i in my_tasks:
+        i=i+1
         if rank==0 and verbose: print("MCN1: Rank %d doing task %d" % (comm.rank,i))
         Xs    = get_kmap((icov,0,i)) # S
         Ysp   = get_kmap((icov,1,i)) # S'


### PR DESCRIPTION
For the act lensing analysis, the get_kmap function is used for both the data and the sims, seed (0,0,0) is used for the data and when testing with simulations seed (0,0,1) is usually used as the 'data'. In the rdn0 function, the unmodified i will call using (0,0,0) again, i.e misusing the real data as a sim.